### PR TITLE
Initial version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/target
+**/*.rs.bk
+Cargo.lock

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,6 @@
+indent_style="Block"
+imports_indent="Block"
+trailing_comma="Never"
+use_try_shorthand=true
+use_field_init_shorthand=true
+merge_imports=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: rust
+rust: nightly
+cache:
+    - cargo
+before_script:
+    - rustup component add --toolchain nightly rustfmt-preview || cargo +nightly install --force rustfmt-nightly
+script:
+    - cargo +nightly fmt --all -- --check
+    - cargo test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "natrob"
+description = "NArrow TRait OBjects: thin pointers to trait objects"
+repository = "https://github.com/softdevteam/natrob/"
+version = "0.1.0"
+authors = ["Laurence Tratt <laurie@tratt.net>"]
+readme = "README.md"
+# This should be "Apache-2.0 OR MIT OR UPL-1.0" but crates.io doesn't know about
+# UPL-1.0.
+license = "Apache-2.0 OR MIT"
+categories = ["development-tools"]
+edition = "2018"
+
+[lib]
+proc-macro = true
+
+[[test]]
+name = "proc_macro_tests"
+path = "proc_macro_tests/run.rs"
+harness = false
+
+[dev-dependencies]
+lang_tester = "0.3"
+tempdir = "0.3"
+
+[dependencies]
+syn = { version="0.15", features=["full"] }
+quote = "0.6"

--- a/proc_macro_tests/run.rs
+++ b/proc_macro_tests/run.rs
@@ -1,0 +1,94 @@
+// Copyright (c) 2019 King's College London created by the Software Development Team
+// <http://soft-dev.org/>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0>, or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, or the UPL-1.0 license <http://opensource.org/licenses/UPL>
+// at your option. This file may not be copied, modified, or distributed except according to those
+// terms.
+
+use std::{fs::read_dir, path::PathBuf, process::Command};
+
+use lang_tester::LangTester;
+use tempdir::TempDir;
+
+#[cfg(debug_assertions)]
+const DEPS_PATH: &str = "target/debug/deps";
+#[cfg(not(debug_assertions))]
+const DEPS_PATH: &str = "target/release/deps";
+
+/// Fish out libnatrob.so from the target/ directory.
+fn natrob_lib() -> String {
+    let mut cnds = Vec::new();
+    for e in read_dir(DEPS_PATH).unwrap() {
+        let path = e.unwrap().path();
+        if path
+            .file_name()
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .starts_with("libnatrob")
+            && path.extension().map(|x| x.to_str().unwrap()) == Some("so")
+        {
+            cnds.push(path.to_str().unwrap().to_owned());
+        }
+    }
+    if cnds.is_empty() {
+        panic!("Can't find libnatrob.so");
+    } else if cnds.len() == 1 {
+        return cnds[0].clone();
+    } else {
+        panic!("Multiple candidates for libnatrob.so");
+    }
+}
+
+fn main() {
+    let tempdir = TempDir::new("proc_macro_tests").unwrap();
+    let natrob_lib = natrob_lib();
+    LangTester::new()
+        .test_dir("proc_macro_tests")
+        // Only use files named `test/*.rs` as test files.
+        .test_file_filter(|p| {
+            p.file_name()
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .starts_with("test_")
+                && p.extension().and_then(|s| Some(s.to_str().unwrap() == "rs")).unwrap_or(false)
+        })
+        // Extract the first sequence of commented line(s) as the tests.
+        .test_extract(|s| {
+            Some(
+                s.lines()
+                    // Skip non-commented lines at the start of the file.
+                    .skip_while(|l| !l.starts_with("//"))
+                    // Extract consecutive commented lines.
+                    .take_while(|l| l.starts_with("//"))
+                    .map(|l| &l[2..])
+                    .collect::<Vec<_>>()
+                    .join("\n"),
+            )
+        })
+        // We have two test commands:
+        //   * `Compiler`: runs rustc.
+        //   * `Run-time`: if rustc does not error, and the `Compiler` tests
+        //     succeed, then the output binary is run.
+        .test_cmds(move |p| {
+            // Test command 1: Compile `x.rs` into `tempdir/x`.
+            let mut exe = PathBuf::new();
+            exe.push(&tempdir);
+            exe.push(p.file_stem().unwrap());
+            let mut compiler = Command::new("rustc");
+            compiler.args(&[
+                "--extern",
+                &format!("natrob={}", natrob_lib),
+                "-o",
+                exe.to_str().unwrap(),
+                p.to_str().unwrap(),
+            ]);
+            // Test command 2: run `tempdir/x`.
+            let runtime = Command::new(exe);
+            vec![("Compiler", compiler), ("Run-time", runtime)]
+        })
+        .run();
+}

--- a/proc_macro_tests/test_basic.rs
+++ b/proc_macro_tests/test_basic.rs
@@ -1,0 +1,60 @@
+// Compiler:
+//   status: success
+//   stderr:
+//   stdout:
+//
+// Run-time:
+//   status: success
+//   stderr:
+//   stdout:
+
+#![feature(alloc_layout_extra)]
+#![feature(coerce_unsized)]
+
+use std::mem::size_of;
+
+extern crate natrob;
+use natrob::narrowable;
+
+#[narrowable(NarrowT)]
+pub trait T { fn f(&self) -> usize; }
+
+struct S1;
+impl T for S1 {
+    fn f(&self) -> usize {
+        1
+    }
+}
+
+struct S2;
+impl T for S2 {
+    fn f(&self) -> usize {
+        2
+    }
+}
+
+struct S3 {
+    x: usize
+}
+impl T for S3 {
+    fn f(&self) -> usize {
+        self.x
+    }
+}
+
+fn main() {
+    assert_eq!(size_of::<NarrowT>(), size_of::<usize>());
+    assert_eq!(size_of::<&NarrowT>(), size_of::<usize>());
+    assert_eq!(size_of::<&dyn T>(), 2 * size_of::<usize>());
+
+    let s1 = NarrowT::new(S1);
+    let s2 = NarrowT::new(S2);
+    let s3 = NarrowT::new(S3 { x: 3 });
+
+    let s1_t: &dyn T = &*s1;
+    let s2_t: &dyn T = &*s2;
+    let s3_t: &dyn T = &*s3;
+    assert_eq!(s1_t.f(), 1);
+    assert_eq!(s2_t.f(), 2);
+    assert_eq!(s3_t.f(), 3);
+}

--- a/proc_macro_tests/test_big_align.rs
+++ b/proc_macro_tests/test_big_align.rs
@@ -1,0 +1,45 @@
+// Compiler:
+//   status: success
+//   stderr:
+//   stdout:
+//
+// Run-time:
+//   status: success
+//   stderr:
+//   stdout:
+
+#![feature(alloc_layout_extra)]
+#![feature(coerce_unsized)]
+
+extern crate natrob;
+use natrob::narrowable;
+
+#[narrowable(NarrowT)]
+pub trait T { fn f(&self) -> usize; }
+
+struct S1;
+impl T for S1 {
+    fn f(&self) -> usize {
+        1
+    }
+}
+
+#[repr(align(1024))]
+struct S2 {
+    x: usize
+}
+impl T for S2 {
+    fn f(&self) -> usize {
+        self.x
+    }
+}
+
+fn main() {
+    let s1 = NarrowT::new(S1);
+    let s2 = NarrowT::new(S2 { x: 2 });
+
+    let s1_t: &dyn T = &*s1;
+    let s2_t: &dyn T = &*s2;
+    assert_eq!(s1_t.f(), 1);
+    assert_eq!(s2_t.f(), 2);
+}

--- a/proc_macro_tests/test_downcast.rs
+++ b/proc_macro_tests/test_downcast.rs
@@ -1,0 +1,35 @@
+// Compiler:
+//   status: success
+//   stderr:
+//   stdout:
+//
+// Run-time:
+//   status: success
+//   stderr:
+//   stdout:
+
+#![feature(alloc_layout_extra)]
+#![feature(coerce_unsized)]
+
+extern crate natrob;
+use natrob::narrowable;
+
+#[narrowable(NarrowT)]
+pub trait T { }
+
+struct S1;
+impl T for S1 { }
+
+struct S2 {
+    x: usize
+}
+impl T for S2 { }
+
+fn main() {
+    let s1 = NarrowT::new(S1);
+    let s2 = NarrowT::new(S2 { x: 2 });
+
+    assert!(s1.downcast::<S1>().is_some());
+    assert!(s1.downcast::<S2>().is_none());
+    assert_eq!(s2.downcast::<S2>().unwrap().x, 2);
+}

--- a/proc_macro_tests/test_mut.rs
+++ b/proc_macro_tests/test_mut.rs
@@ -1,0 +1,45 @@
+// Compiler:
+//   status: success
+//   stderr:
+//   stdout:
+//
+// Run-time:
+//   status: success
+//   stderr:
+//   stdout:
+
+#![feature(alloc_layout_extra)]
+#![feature(coerce_unsized)]
+
+extern crate natrob;
+use natrob::narrowable;
+
+#[narrowable(NarrowT)]
+pub trait T { fn f(&mut self, x: usize) -> usize; }
+
+struct S1;
+impl T for S1 {
+    fn f(&mut self, _: usize) -> usize {
+        1
+    }
+}
+
+struct S2 {
+    x: usize
+}
+impl T for S2 {
+    fn f(&mut self, x: usize) -> usize {
+        let old = self.x;
+        self.x = x;
+        old
+    }
+}
+
+fn main() {
+    let mut s1 = NarrowT::new(S1);
+    let mut s2 = NarrowT::new(S2 { x: 2 });
+
+    assert_eq!(s1.f(42), 1);
+    assert_eq!(s2.f(3), 2);
+    assert_eq!(s2.f(4), 3);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,6 +107,17 @@ pub fn narrowable(args: TokenStream, input: TokenStream) -> TokenStream {
             }
         }
 
+        impl ::std::ops::DerefMut for #struct_id {
+            fn deref_mut(&mut self) -> &mut (dyn #trait_id + 'static) {
+                unsafe {
+                    let vtableptr = self.objptr.sub(::std::mem::size_of::<usize>());
+                    let vtable = ::std::ptr::read(vtableptr as *mut usize);
+                    ::std::mem::transmute::<(*const _, usize), &mut dyn #trait_id>(
+                        (self.objptr, vtable))
+                }
+            }
+        }
+
         impl ::std::ops::Drop for #struct_id {
             fn drop(&mut self) {
                 let fatptr = unsafe {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,137 @@
+// Copyright (c) 2019 King's College London created by the Software Development Team
+// <http://soft-dev.org/>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0>, or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, or the UPL-1.0 license <http://opensource.org/licenses/UPL>
+// at your option. This file may not be copied, modified, or distributed except according to those
+// terms.
+
+#![recursion_limit = "256"]
+
+extern crate proc_macro;
+
+use crate::proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, AttributeArgs, ItemTrait, NestedMeta};
+
+#[proc_macro_attribute]
+pub fn narrowable(args: TokenStream, input: TokenStream) -> TokenStream {
+    let args = parse_macro_input!(args as AttributeArgs);
+    let input = parse_macro_input!(input as ItemTrait);
+    if args.len() != 1 {
+        panic!("Need precisely one argument to 'narrowable'");
+    }
+    let struct_id = match &args[0] {
+        NestedMeta::Meta(m) => m.name(),
+        NestedMeta::Literal(_) => panic!("Literals not valid attributes to 'narrowable'")
+    };
+    let trait_id = &input.ident;
+    let expanded = quote! {
+        /// A narrow pointer to #trait_id.
+        #[repr(C)]
+        struct #struct_id {
+            // A pointer to an object; immediately preceding that object is a usized pointer to the
+            // object's vtable. In other words, on a 64 bit machine the layout is (in bytes):
+            //   -8..-1: vtable
+            //   0..: object
+            // Note that:
+            //   1) Depending on the alignment of `object`, the allocated block of memory might
+            //      start *before* -8 bytes. To calculate the beginning of the block of memory you
+            //      need to know the alignment of both the vtable pointer and `object` (see
+            //      `Drop::drop` below).
+            //   2) If `object` is zero-sized the pointer might be to the very end of the block, so
+            //      you mustn't blindly load bytes from this pointer.
+            // The reason for this complex dance is that we're trying to optimise the common case
+            // of converting this thin pointer into a fat pointer. However, we can only know
+            // `object`'s alignment by looking it up in the vtable: if the user doesn't then call
+            // anything in the vtable, we've loaded the vtable's cache line for no good reason.
+            // Using the layout above, we can avoid doing this load entirely except in the less
+            // common case of dropping the pointer.
+            objptr: *mut u8
+        }
+
+        impl #struct_id {
+            /// Create a new narrow pointer to #trait_id.
+            pub fn new<U>(v: U) -> Self
+            where
+                *const U: ::std::ops::CoerceUnsized<*const (dyn #trait_id + 'static)>,
+                U: #trait_id + 'static
+            {
+                let (layout, uoff) = ::std::alloc::Layout::new::<usize>().extend(
+                    ::std::alloc::Layout::new::<U>()).unwrap();
+                // In order for our storage scheme to work, it's necessary that `uoff -
+                // sizeof::<usize>()` gives a valid alignment for a `usize`. There are only two
+                // cases we need to consider here:
+                //   1) `object`'s alignment is smaller than or equal to `usize`. If so, no padding
+                //      will be added, at which point by definition `uoff - sizeof::<usize>()` will
+                //      be exactly equivalent to the start point of the layout.
+                //   2) `object`'s alignment is bigger than `usize`. Since alignment must be a
+                //      power of two, that means that we must by definition be adding at least one
+                //      exact multiple of `usize` bytes of padding.
+                // The assert below is thus paranoia writ large: it could only trigger if `Layout`
+                // started adding amounts of padding that directly contradict the documentation.
+                debug_assert_eq!(uoff % ::std::mem::align_of::<usize>(), 0);
+
+                let objptr = unsafe {
+                    let baseptr = ::std::alloc::alloc(layout);
+                    let objptr = baseptr.add(uoff);
+                    let vtableptr = objptr.sub(::std::mem::size_of::<usize>());
+                    let t: &dyn #trait_id = &v;
+                    let vtable = ::std::mem::transmute::<*const dyn #trait_id, (usize, usize)>(t).1;
+                    ::std::ptr::write(vtableptr as *mut usize, vtable);
+                    if ::std::mem::size_of::<U>() != 0 {
+                        objptr.copy_from_nonoverlapping(&v as *const U as *const u8,
+                            ::std::mem::size_of::<U>());
+                    }
+                    objptr
+                };
+                ::std::mem::forget(v);
+
+                #struct_id {
+                    objptr
+                }
+            }
+        }
+
+        impl ::std::ops::Deref for #struct_id {
+            type Target = dyn #trait_id;
+
+            fn deref(&self) -> &(dyn #trait_id + 'static) {
+                unsafe {
+                    let vtableptr = self.objptr.sub(::std::mem::size_of::<usize>());
+                    let vtable = ::std::ptr::read(vtableptr as *mut usize);
+                    ::std::mem::transmute::<(*const _, usize), &dyn #trait_id>(
+                        (self.objptr, vtable))
+                }
+            }
+        }
+
+        impl ::std::ops::Drop for #struct_id {
+            fn drop(&mut self) {
+                let fatptr = unsafe {
+                    let vtableptr = self.objptr.sub(::std::mem::size_of::<usize>());
+                    let vtable = ::std::ptr::read(vtableptr as *mut usize);
+                    ::std::mem::transmute::<(*const _, usize), &mut dyn #trait_id>(
+                        (self.objptr, vtable))
+                };
+
+                // Call `drop` on the trait object before deallocating memory.
+                unsafe { ::std::ptr::drop_in_place(fatptr as *mut dyn #trait_id) };
+
+                let align = ::std::mem::align_of_val(fatptr);
+                let size = ::std::mem::size_of_val(fatptr);
+                unsafe {
+                    let (layout, uoff) = ::std::alloc::Layout::new::<usize>().extend(
+                        ::std::alloc::Layout::from_size_align_unchecked(size, align)).unwrap();
+                    let baseptr = self.objptr.sub(uoff);
+                    ::std::alloc::dealloc(baseptr, layout);
+                }
+            }
+        }
+
+        #input
+    };
+
+    TokenStream::from(expanded)
+}


### PR DESCRIPTION
This is a very basic version of narrow trait objects. The first commit does the bulk of the work and the second adds the ability to downcast to a specific type. More will need to be done, but this is a reasonable start. The commit message for https://github.com/softdevteam/natrob/commit/359be4b5382bc0476868ff8889b7b97f01cadd69 has most of the useful details.

There remain issues to tackle. Notably I do not understand if/how Rust's procedural macros and thus I can see unwanted dynamic scoping happening: if you use this on a trait with a name `U`, for example, you'll get extremely confusing errors (because `U` is a type parameter name in the code we generate via a macro). Judging by what little information I can find online, hygiene is very much a work-in-progress for Rust macros, so we might not be able to do very much about this: if I'm wrong (or if the situation changes in the future) retro-fitting hygiene probably won't be an undue amount of work, so I think it's something we can put off for a bit.