### PR TITLE
Add a natrob proc macro for abgc.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,6 @@ tempdir = "0.3"
 [dependencies]
 syn = { version="0.15", features=["full"] }
 quote = "0.6"
+
+[features]
+abgc = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,3 +167,133 @@ pub fn narrowable(args: TokenStream, input: TokenStream) -> TokenStream {
 
     TokenStream::from(expanded)
 }
+
+#[cfg(feature = "abgc")]
+#[proc_macro_attribute]
+pub fn narrowable_abgc(args: TokenStream, input: TokenStream) -> TokenStream {
+    let args = parse_macro_input!(args as AttributeArgs);
+    let input = parse_macro_input!(input as ItemTrait);
+    if args.len() != 1 {
+        panic!("Need precisely one argument to 'narrowable'");
+    }
+    let struct_id = match &args[0] {
+        NestedMeta::Meta(m) => m.name(),
+        NestedMeta::Literal(_) => panic!("Literals not valid attributes to 'narrowable'")
+    };
+    let trait_id = &input.ident;
+    let expanded = quote! {
+        /// A narrow pointer to #trait_id.
+        pub struct #struct_id;
+        // This struct points to a vtable pointer followed by an object. In other words, on a
+        // 64 bit machine the layout is (in bytes):
+        //   0..7: vtable
+        //   8..: object
+        // This is an inflexible layout, since we can only support structs whose alignment is the
+        // same or less than a usize's. However, we're stuck for the time being, since abgc can't
+        // handle interior pointers.
+
+        impl #struct_id {
+            /// Create a new narrow pointer to #trait_id.
+            pub fn new<U>(v: U) -> ::abgc::Gc<Self>
+            where
+                *const U: ::std::ops::CoerceUnsized<*const (dyn #trait_id + 'static)>,
+                U: #trait_id + 'static
+            {
+                let (layout, uoff) = ::std::alloc::Layout::new::<usize>().extend(
+                    ::std::alloc::Layout::new::<U>()).unwrap();
+                // Check that we've not been given an object whose alignment exceeds that of a
+                // size: we can't handle such cases until abgc can store interior pointers.
+                debug_assert_eq!(uoff, ::std::mem::size_of::<usize>());
+
+                let baseptr = ::abgc::Gc::<#struct_id>::alloc_blank(layout);
+                unsafe {
+                    let objptr = (baseptr as *mut u8).add(uoff);
+                    let t: &dyn #trait_id = &v;
+                    let vtable = ::std::mem::transmute::<*const dyn #trait_id, (usize, usize)>(t).1;
+                    ::std::ptr::write(baseptr as *mut usize, vtable);
+                    if ::std::mem::size_of::<U>() != 0 {
+                        objptr.copy_from_nonoverlapping(&v as *const U as *const u8,
+                            ::std::mem::size_of::<U>());
+                    }
+                }
+                ::std::mem::forget(v);
+
+                unsafe { ::abgc::Gc::from_raw(baseptr) }
+            }
+
+            pub unsafe fn recover(o: &dyn Obj) -> ::abgc::Gc<#struct_id> {
+                let objptr = o as *const _;
+                let baseptr = (objptr as *const usize).sub(1);
+                Gc::recover(baseptr as *const u8 as *const #struct_id)
+            }
+
+            /// Try casting this narrow trait object to a concrete struct type `U`, returning
+            /// `Some(...)` if this narrow trait object has stored an object of type `U` or `None`
+            /// otherwise.
+            pub fn downcast<U: #trait_id>(&self) -> Option<&U> {
+                let t_vtable = {
+                    let t: &dyn #trait_id = unsafe { &*(0 as *const U) };
+                    unsafe { ::std::mem::transmute::<&dyn #trait_id, (usize, usize)>(t) }.1
+                };
+
+                let vtable = unsafe {
+                    ::std::ptr::read(self as *const _ as *const usize)
+                };
+
+                if t_vtable == vtable {
+                    let objptr = unsafe { (self as *const _ as *const usize).add(1) };
+                    Some(unsafe { &*(objptr as *const U) })
+                } else {
+                    None
+                }
+            }
+        }
+
+        impl ::std::ops::Deref for #struct_id {
+            type Target = dyn #trait_id;
+
+            fn deref(&self) -> &(dyn #trait_id + 'static) {
+                unsafe {
+                    let vtable = ::std::ptr::read(self as *const _ as *const usize as *mut usize);
+                    let objptr = (self as *const _ as *const usize).add(1);
+                    ::std::mem::transmute::<(*const _, usize), &dyn #trait_id>(
+                        (objptr, vtable))
+                }
+            }
+        }
+
+        impl ::std::ops::Drop for #struct_id {
+            fn drop(&mut self) {
+                let fatptr = unsafe {
+                    let vtable = ::std::ptr::read(self as *const _ as *const usize as *mut usize);
+                    let objptr = (self as *const _ as *const usize).add(1);
+                    ::std::mem::transmute::<(*const _, usize), &mut dyn #trait_id>(
+                        (objptr, vtable))
+                };
+
+                // Call `drop` on the trait object before deallocating memory.
+                unsafe { ::std::ptr::drop_in_place(fatptr as *mut dyn #trait_id) };
+            }
+        }
+
+        impl ::abgc::GcLayout for #struct_id {
+            fn layout(&self) -> ::std::alloc::Layout {
+                let fatptr = unsafe {
+                    let vtable = ::std::ptr::read(self as *const _ as *const usize as *mut usize);
+                    let objptr = (self as *const _ as *const usize).add(1);
+                    ::std::mem::transmute::<(*const _, usize), &mut dyn #trait_id>(
+                        (objptr, vtable))
+                };
+
+                let align = ::std::mem::align_of_val(fatptr);
+                let size = ::std::mem::size_of_val(fatptr);
+                let obj_layout = unsafe { ::std::alloc::Layout::from_size_align_unchecked(size, align) };
+                ::std::alloc::Layout::new::<usize>().extend(obj_layout).unwrap().0
+            }
+        }
+
+        #input
+    };
+
+    TokenStream::from(expanded)
+}


### PR DESCRIPTION
Unfortunately this is surprisingly dissimilar to the "normal" natrob. The most fundamental problem is that Gc::alloc_blank gives us a pointer which we have to return intact to Gc::from_raw. That means we can't use the trick "normal" natrob uses of returning a pointer *after* the vtable (i.e. an interior
pointer): we have to fall back to our old plan of the layout being `(vtable, object)`, which means that `object` can't have a bigger alignment than a `usize`. This isn't likely to cause us many problems in practise, though it is unsatisfying.

It's also a bit annoying that all proc macros have to reside in lib.rs, but that's forced upon us by current limitations in rustc.