### PR TITLE
Add a natrob proc macro for gcmalloc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,4 @@ quote = "0.6"
 
 [features]
 abgc = []
+gcmalloc = []


### PR DESCRIPTION
This is similar to the abgc proc_macro. We use the
`Gc::<T>::new_from_layout` API in gcmalloc to allocate some
uninitialized memory for our narrow trait object.