### PR TITLE
Add a recover_gc function.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -341,6 +341,17 @@ pub fn narrowable_rboehm(args: TokenStream, input: TokenStream) -> TokenStream {
                 Gc::from_raw(baseptr as *const u8 as *const #struct_id)
             }
 
+            /// Convert a downcasted narrow trait object back into a normal narrow trait object.
+            /// This will lead to undefined behaviour if `o` was not originally a narrow trait
+            /// object.
+            pub unsafe fn recover_gc<T: #trait_id>(o: Gc<T>) -> ::rboehm::Gc<#struct_id> {
+                unsafe {
+                    let objptr = Gc::into_raw(o);
+                    let baseptr = (objptr as *const usize).sub(1);
+                    Gc::from_raw(baseptr as *const u8 as *const #struct_id)
+                }
+            }
+
             /// Try casting this narrow trait object to a concrete struct type
             /// `U`, returning `Some(...)` if this narrow trait object has
             /// stored an object of type `U` or `None` otherwise.


### PR DESCRIPTION
This is very similar to the `recover` function although slightly harder (but definitely not impossible) to abuse. For example if you have a narrow trait type Obj and a concrete type Class which implements that trait, this code leads to undefined behaviour:

```
  let x = Gc::new(Class { ... });
  let to = unsafe { Obj::recover_gc(x) };
```

because `x` was never a narrow trait object in the first place.