### PR TITLE
Add a proc macro for rustc_boehm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,4 @@ quote = "0.6"
 abgc = []
 gcmalloc = []
 rboehm = []
+rustc_boehm = []


### PR DESCRIPTION
Providing rustc_boehm is the current toolchain, it should be possible to
use this new proc macro in the same way that rboehm is used.