### PR TITLE
[narrowable_rboehm]: Don't finalize `ThinObj` if it's unnecessary

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -236,7 +236,12 @@ pub fn narrowable_rboehm(args: TokenStream, input: TokenStream) -> TokenStream {
                     ::std::ptr::write(vtablep as *mut usize, vtable);
 
                     init(objp as *mut U);
-                    gc.assume_init()
+                    let mut init = gc.assume_init();
+
+                    if !::rboehm::gc::needs_finalizer::<U>() {
+                        init.unregister_finalizer()
+                    }
+                    init
                 }
             }
 


### PR DESCRIPTION
The `Drop` method for `ThinObj` acts as simple drop glue to call the
inner `Obj`'s drop method. Unfortunately, this creates false positives
in our `needs_finalize` analysis since rboehm thinks it's always
required.

This change will unregister the finalizer for the narrow trait object if
it's clear that it's unnecessary for the inner type.