### PR TITLE
Only build proc-macro tests.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ proc-macro = true
 name = "proc_macro_tests"
 path = "proc_macro_tests/run.rs"
 harness = false
+crate-type = ["proc-macro"]
 
 [dev-dependencies]
 lang_tester = "0.3"


### PR DESCRIPTION
I think that, without this, we probably have a situation where `crate-type = ["lib", "proc-macro"]` or similar, hence why we're building two test suites. It probably doesn't matter very much *what* crate-type we pick, because lang_tester is doing most of the hard work -- we just need to make sure it's only called once!

This should allow https://github.com/softdevteam/natrob/pull/29 to progress.