### PR TITLE
NoFinalize now needs to be unsafe.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -201,7 +201,7 @@ pub fn narrowable_libgc(args: TokenStream, input: TokenStream) -> TokenStream {
 
         unsafe impl<U: Send> Send for #struct_union_id<U> {}
 
-        impl<U: ::std::gc::NoFinalize> ::std::gc::NoFinalize for #struct_union_id<U> {}
+        unsafe impl<U: ::std::gc::NoFinalize> ::std::gc::NoFinalize for #struct_union_id<U> {}
 
         impl<U> ::std::ops::Drop for #struct_union_id<U> {
             fn drop(&mut self) {


### PR DESCRIPTION
This is a result of
https://github.com/softdevteam/rustgc/commit/5ebb0fa36946e6cf687e995879d9986a1d1abc9a.